### PR TITLE
rustfmt and clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl FuseProperty {
     pub fn init_with_weight(value: &str, weight: f64) -> Self {
         Self {
             value: String::from(value),
-            weight: weight,
+            weight,
         }
     }
 }
@@ -189,9 +189,9 @@ impl Fuse {
             let alphabet = utils::calculate_pattern_alphabet(&pattern);
             let new_pattern = Pattern {
                 text: String::from(pattern),
-                len: len,
+                len,
                 mask: 1 << (len - 1),
-                alphabet: alphabet,
+                alphabet,
             };
             Some(new_pattern)
         }
@@ -333,7 +333,7 @@ impl Fuse {
         }
 
         ScoreResult {
-            score: score,
+            score,
             ranges: utils::find_ranges(&match_mask_arr).unwrap(),
         }
     }
@@ -364,9 +364,9 @@ impl Fuse {
             let (length, results) = word_patterns.fold(
                 (0, full_pattern_result),
                 |(n, mut total_result), pattern| {
-                    let result = self.search_util(&pattern, string);
+                    let mut result = self.search_util(&pattern, string);
                     total_result.score += result.score;
-                    total_result.ranges.append(&mut result.ranges.clone());
+                    total_result.ranges.append(&mut result.ranges);
                     (n + 1, total_result)
                 },
             );
@@ -376,18 +376,18 @@ impl Fuse {
                 ranges: results.ranges,
             };
 
-            return if averaged_result.score == 1. {
+            if averaged_result.score == 1. {
                 None
             } else {
                 Some(averaged_result)
-            };
+            }
         } else {
             let result = self.search_util(&pattern, string);
-            return if result.score == 1. {
+            if result.score == 1. {
                 None
             } else {
                 Some(result)
-            };
+            }
         }
     }
 }
@@ -482,7 +482,7 @@ impl Fuse {
         for (index, item) in list.into_iter().enumerate() {
             if let Some(result) = self.search(pattern.as_ref(), item.as_ref()) {
                 items.push(SearchResult {
-                    index: index,
+                    index,
                     score: result.score,
                     ranges: result.ranges,
                 })
@@ -534,7 +534,7 @@ impl Fuse {
                 scope.spawn(move |_| {
                     let mut chunk_items = vec![];
 
-                    for (index, item) in chunk.into_iter().enumerate() {
+                    for (index, item) in chunk.iter().enumerate() {
                         if let Some(result) = self.search((*pattern_ref).as_ref(), item) {
                             chunk_items.push(SearchResult {
                                 index: offset + index,
@@ -641,7 +641,7 @@ impl Fuse {
 
                     property_results.push(FResult {
                         value: String::from(&property.value),
-                        score: score,
+                        score,
                         ranges: result.ranges,
                     });
                 }
@@ -652,14 +652,14 @@ impl Fuse {
 
             let count = scores.len() as f64;
             result.push(FuseableSearchResult {
-                index: index,
+                index,
                 score: total_score / count,
                 results: property_results,
             })
         }
 
         result.sort_unstable_by(|a, b| a.score.partial_cmp(&b.score).unwrap());
-        return result;
+        result
     }
 
     /// Asynchronously searches for a text pattern in an array of `Fuseable` objects.
@@ -728,7 +728,7 @@ impl Fuse {
                 scope.spawn(move |_| {
                     let mut chunk_items = vec![];
 
-                    for (index, item) in chunk.into_iter().enumerate() {
+                    for (index, item) in chunk.iter().enumerate() {
                         let mut scores = vec![];
                         let mut total_score = 0.0;
 
@@ -755,7 +755,7 @@ impl Fuse {
 
                                 property_results.push(FResult {
                                     value: String::from(&property.value),
-                                    score: score,
+                                    score,
                                     ranges: result.ranges,
                                 });
                             }
@@ -767,7 +767,7 @@ impl Fuse {
 
                         let count = scores.len() as f64;
                         chunk_items.push(FuseableSearchResult {
-                            index: index,
+                            index,
                             score: total_score / count,
                             results: property_results,
                         })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,29 +6,18 @@ pub fn calculate_score_with_string(
     e: i32,
     x: i32,
     loc: i32,
-    distance: i32) -> f64 {
-        calculate_score(
-            pattern.len(),
-            e,
-            x,
-            loc,
-            distance,
-        )
+    distance: i32,
+) -> f64 {
+    calculate_score(pattern.len(), e, x, loc, distance)
 }
 
-pub fn calculate_score(
-    pattern_length: usize,
-    e: i32,
-    x: i32,
-    loc: i32,
-    distance: i32) -> f64 {
-    
+pub fn calculate_score(pattern_length: usize, e: i32, x: i32, loc: i32, distance: i32) -> f64 {
     let accuracy = (e as f64) / (pattern_length as f64);
     let proximity = (x - loc).abs();
     if distance == 0 {
-        return if proximity != 0 { 1. } else { accuracy as f64} 
+        return if proximity != 0 { 1. } else { accuracy as f64 };
     }
-    accuracy + (proximity as f64) / ( distance as f64)
+    accuracy + (proximity as f64) / (distance as f64)
 }
 
 /// Initializes the alphabet for the Bitap algorithm
@@ -38,7 +27,7 @@ pub fn calculate_pattern_alphabet(pattern: &str) -> HashMap<char, u32> {
     let len = pattern.len();
     let mut mask = HashMap::new();
     for (i, c) in pattern.chars().enumerate() {
-        mask.insert(c, mask.get(&c).unwrap_or(&0) | (1 << (len -i -1)));
+        mask.insert(c, mask.get(&c).unwrap_or(&0) | (1 << (len - i - 1)));
     }
     mask
 }
@@ -50,10 +39,10 @@ pub fn find_ranges(mask: &[u8]) -> Result<Vec<Range<usize>>, String> {
     if mask.is_empty() {
         return Err(String::from("Input array is empty"));
     }
-    let mut ranges = vec!();
+    let mut ranges = vec![];
     let mut start: i32 = -1;
     for (n, bit) in mask.iter().enumerate() {
-        if start == -1 && *bit >= 1{
+        if start == -1 && *bit >= 1 {
             start = n as i32;
         } else if start != -1 && *bit == 0 {
             ranges.push(start as usize..n);


### PR DESCRIPTION
I don't know if you are aware but `rustfmt` and `clippy` are [super useful tools for rust development](https://doc.rust-lang.org/book/appendix-04-useful-development-tools.html). I know you said you where using this project to learn rust so feel free to discard this PR and run them yourself.

The remaining clippy lints concern exact comparisons with f64, which is generally [not a good idea](https://rust-lang.github.io/rust-clippy/master/index.html#float_cmp). I would have to take a closer look at how this could be resolved, prehaps `search_util` could return `Option<ScoreResult>` (i.e. return `None` if no match is found), then use `?` at call sites to return if there was no match.