### PR TITLE
Use crossbeam_utils instead crossbeam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,76 +8,15 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "crossbeam"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "lazy_static",
- "maybe-uninit",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "maybe-uninit",
-]
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -88,7 +27,7 @@ dependencies = [
 name = "fuse-rust"
 version = "0.1.3"
 dependencies = [
- "crossbeam",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -96,24 +35,3 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
-name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ Fuse-Rust is a port of Fuse-Swift, written purely in rust.
 """
 
 [dependencies]
-crossbeam = "0.7.3"
+crossbeam-utils = "0.8.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod tests;
 mod utils;
 
 /// Required for scoped threads
-use crossbeam::thread;
+use crossbeam_utils::thread;
 use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
It seems that crossbeam only used for threading, so no need to depending on the whole framework, but only utils part.

Before:

```
fuse-rust v0.1.3
└── crossbeam v0.7.3
    ├── cfg-if v0.1.10
    ├── crossbeam-channel v0.4.4
    │   ├── crossbeam-utils v0.7.2
    │   │   ├── cfg-if v0.1.10
    │   │   └── lazy_static v1.4.0
    │   │   [build-dependencies]
    │   │   └── autocfg v1.0.1
    │   └── maybe-uninit v2.0.0
    ├── crossbeam-deque v0.7.3
    │   ├── crossbeam-epoch v0.8.2
    │   │   ├── cfg-if v0.1.10
    │   │   ├── crossbeam-utils v0.7.2 (*)
    │   │   ├── lazy_static v1.4.0
    │   │   ├── maybe-uninit v2.0.0
    │   │   ├── memoffset v0.5.6
    │   │   │   [build-dependencies]
    │   │   │   └── autocfg v1.0.1
    │   │   └── scopeguard v1.1.0
    │   │   [build-dependencies]
    │   │   └── autocfg v1.0.1
    │   ├── crossbeam-utils v0.7.2 (*)
    │   └── maybe-uninit v2.0.0
    ├── crossbeam-epoch v0.8.2 (*)
    ├── crossbeam-queue v0.2.3
    │   ├── cfg-if v0.1.10
    │   ├── crossbeam-utils v0.7.2 (*)
    │   └── maybe-uninit v2.0.0
    └── crossbeam-utils v0.7.2 (*)
```

and after:

```
fuse-rust v0.1.3
└── crossbeam-utils v0.8.1
    ├── cfg-if v1.0.0
    └── lazy_static v1.4.0
    [build-dependencies]
    └── autocfg v1.0.1
```